### PR TITLE
Add "Hello, world" JS sample with Closure Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 How to build applications using [Stimulus.js][stimulus-js].
 
-Sample apps:
+Working sample apps:
 
+* ["Hello world" in JavaScript][stimulus-hello-world-js]
 * ["Hello world" in TypeScript with Bazel][stimulus-hello-world-ts]
+
+Works-in-progress (not working yet):
+
+* ["Hello world" in JavaScript with Bazel][stimulus-hello-world-js-closure]
 
 ## Contributing
 
@@ -21,4 +26,6 @@ and Google specifically disclaims all warranties as to its quality,
 merchantability, or fitness for a particular purpose.
 
 [stimulus-js]: https://stimulusjs.org/
+[stimulus-hello-world-js]: third_party/stimulus/hello-world-js
+[stimulus-hello-world-js-closure]: third_party/stimulus/hello-world-js-closure
 [stimulus-hello-world-ts]: third_party/stimulus/hello-world-ts

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,8 @@ workspace(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Node.js + TypeScript support
+
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "64a71a64ac58b8969bb19b1c9258a973b6433913e958964da698943fb5521d98",
@@ -37,3 +39,19 @@ yarn_install(
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )
+
+# Closure support
+
+http_archive(
+    name = "io_bazel_rules_closure",
+    sha256 = "d66deed38a0bb20581c15664f0ab62270af5940786855c7adc3087b27168b529",
+    strip_prefix = "rules_closure-0.11.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.11.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.11.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
+rules_closure_dependencies()
+rules_closure_toolchains()

--- a/third_party/stimulus/hello-world-js-closure/BUILD
+++ b/third_party/stimulus/hello-world-js-closure/BUILD
@@ -1,0 +1,43 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@io_bazel_rules_closure//closure:defs.bzl",
+    "closure_js_binary",
+    "closure_js_library",
+)
+
+closure_js_library(
+    name = "hello_controller",
+    srcs = ["hello_controller.js"],
+    no_closure_library = True,
+    deps = [
+        "//third_party/stimulus/v1_1_1/externs",
+    ],
+)
+
+closure_js_binary(
+    name = "app",
+    compilation_level = "ADVANCED",
+    dependency_mode = "PRUNE",
+    entry_points = ["third_party/stimulus/hello-world-js-closure/hello_controller"],
+    deps = [":hello_controller"],
+)
+
+genrule(
+    name = "html",
+    srcs = ["index.html"],
+    outs = ["app.html"],
+    cmd = "sed 's/hello_controller.js/app.js/' < $(location :index.html) > $(location :app.html)",
+)

--- a/third_party/stimulus/hello-world-js-closure/README.md
+++ b/third_party/stimulus/hello-world-js-closure/README.md
@@ -1,0 +1,28 @@
+# Stimulus with JavaScript and Closure Compiler
+
+## Open raw HTML with uncompiled JavaScript
+
+Simply open [`index.html`](index.html) in your browser, it will use the
+uncompiled [`hello_controller.js`](hello_controller.js) which works as-is.
+
+## Build JavaScript with Closure Compiler
+
+This is using Closure-compatible extern definitions in
+[`//third_party/stimulus/v1_1_1/externs`][stimulus-externs]; Stimulus will be
+loaded from a CDN.
+
+Build command:
+
+```sh
+$ bazel build :app
+```
+
+**Note:** this currently fails to build due to [a bug in Closure
+Compiler][closure-compiler-bug] which has been fixed, but a new version of
+Closure Compiler hasn't been released yet. Once a new version of the compiler is
+released and incorporated into [Bazel rules for Closure][bazel-rules-closure],
+we can retry this build to see if this has been fixed.
+
+[stimulus-externs]: ../v1_1_1/externs
+[closure-compiler-bug]: https://github.com/google/closure-compiler/issues/3687
+[bazel-rules-closure]: https://github.com/bazelbuild/rules_closure

--- a/third_party/stimulus/hello-world-js-closure/hello_controller.js
+++ b/third_party/stimulus/hello-world-js-closure/hello_controller.js
@@ -1,0 +1,57 @@
+const { Application, Controller } = window.Stimulus;
+
+class ControllerHelper extends Controller {
+  /**
+   * @param {!string} name
+   * @returns {!HTMLInputElement}
+   * @protected
+   */
+  getInput(name) {
+    return /** @type {!HTMLInputElement} */ (this.getElement(name));
+  }
+
+  /**
+   * @param {!string} name
+   * @returns {!HTMLSpanElement}
+   * @protected
+   */
+  getSpan(name) {
+    return /** @type {!HTMLSpanElement} */ (this.getElement(name));
+  }
+
+  /**
+   * @param {!string} name
+   * @returns {!Element}
+   * @protected
+   */
+  getElement(name) {
+    return /** @type {!Element} */ (this.targets.find(name));
+  }
+}
+
+class HelloController extends ControllerHelper {
+  /** @returns {!Array<!string>} */
+  static get targets() {
+    return ["name", "output"];
+  }
+
+  /** @returns {!HTMLInputElement} */
+  get nameTarget() {
+    return this.getInput("name");
+  }
+
+  /** @returns {!HTMLSpanElement} */
+  get outputTarget() {
+    return this.getSpan("output");
+  }
+
+  /** Show a greeting. */
+  greet() {
+    this.outputTarget.textContent =
+      `Hello, ${this.nameTarget.value}!`;
+  }
+}
+
+/** @type {!Stimulus.Application} */
+const app = Application.start();
+app.register("hello", HelloController);

--- a/third_party/stimulus/hello-world-js-closure/index.html
+++ b/third_party/stimulus/hello-world-js-closure/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Stimulus: hello world</title>
+    <script src="https://cdn.jsdelivr.net/npm/stimulus@1.1.1/dist/stimulus.umd.min.js"></script>
+    <script src="hello_controller.js"></script>
+  </head>
+  <body>
+    <div data-controller="hello">
+      <input data-target="hello.name" type="text">
+
+      <button data-action="click->hello#greet">
+        Greet
+      </button>
+
+      <span data-target="hello.output"></span>
+    </div>
+  </body>
+</html>

--- a/third_party/stimulus/v1_1_1/externs/BUILD
+++ b/third_party/stimulus/v1_1_1/externs/BUILD
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+
+closure_js_library(
+    name = "externs",
+    srcs = glob(["*.js"]),
+    no_closure_library = True,
+    visibility = ["//visibility:public"],
+)

--- a/third_party/stimulus/v1_1_1/externs/action.js
+++ b/third_party/stimulus/v1_1_1/externs/action.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Externs for `action.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/action.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+Stimulus.Action = class {
+
+  /**
+   *
+   * @param {!Element} element
+   * @param {!number} index
+   * @param {*} descriptor (technically: Partial<ActionDescriptor>)
+   */
+  constructor(element, index, descriptor) {
+    /** @type {!Element} */
+    this.element;
+
+    /** @type {!number} */
+    this.index;
+
+    /** @type {!EventTarget} */
+    this.eventTarget;
+
+    /** @type {!string} */
+    this.eventName;
+
+    /** @type {!string} */
+    this.identifier;
+
+    /** @type {!string} */
+    this.methodName;
+  }
+
+  /** @returns {!string} */
+  toString() { }
+};
+
+/**
+ * Static factory method.
+ *
+ * @param {*} token (technically, !Stimulus.Token)
+ * @returns {!Stimulus.Action}
+ */
+Stimulus.Action.forToken = function(token) {  };
+
+/**
+ *
+ * @param {!Element} element
+ * @returns {?string}
+ */
+Stimulus.getDefaultEventNameForElement = function (element) { };

--- a/third_party/stimulus/v1_1_1/externs/application.js
+++ b/third_party/stimulus/v1_1_1/externs/application.js
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Externs for `application.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/application.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @implements {Stimulus.ErrorHandler}
+ */
+Stimulus.Application = class {
+  /**
+   *
+   * @param {Element=} element
+   * @param {Stimulus.Schema=} schema
+   */
+  constructor(element = document.documentElement, schema = Stimulus.defaultSchema) {
+    /** @type {Element} */
+    this.element;
+
+    /** @type {Stimulus.Schema} */
+    this.schema;
+
+    /** @type {Stimulus.Dispatcher} */
+    this.dispatcher;
+
+    /** @type {Stimulus.Router} */
+    this.router;
+  }
+
+  /**
+   *
+   * @param {Element=} element
+   * @param {Stimulus.Schema=} schema
+   * @return {!Stimulus.Application}
+   */
+  static start(element, schema) {}
+
+  /** */
+  async start() {  }
+
+  /** */
+  stop() {  }
+
+  /**
+   * @param {!string} identifier
+   * @param {Function} controllerConstructor Technically, this should be `Stimulus.ControllerConstructor` but that doesn't work, and neither does `function(!Stimulus.Context): !Stimulus.Controller`.
+   */
+  register(identifier, controllerConstructor) {  }
+
+  /**
+   * @param {(!Stimulus.Definition|!Array<!Stimulus.Definition>)=} head
+   * @param {...!Stimulus.Definition} rest
+   * @return {undefined}
+   */
+  load(head, ...rest) {}
+
+  // load(...definitions: Definition[]): void
+  // load(definitions: Definition[]): void
+  // load(head: Definition | Definition[], ...rest: Definition[]) { }
+
+  /**
+   *
+   * @param {(!string|!Array<!string>)=} head
+   * @param {...!string} rest
+   * @return {undefined}
+   */
+  unload(head, ...rest) {}
+
+  // unload(...identifiers: string[]): void
+  // unload(identifiers: string[]): void
+  // unload(head: string | string[], ...rest: string[]) {  }
+
+  // Controllers
+
+  /**
+   * @return {!Array<!Stimulus.Controller>}
+   */
+  controllers() {}
+
+  /**
+   *
+   * @param {Element} element
+   * @param {string} identifier
+   * @return {?Stimulus.Controller}
+   */
+  getControllerForElementAndIdentifier(element, identifier) { }
+
+  // getControllerForElementAndIdentifier(element: Element, identifier: string): Controller | null { }
+
+  // Error handling
+
+  /**
+   *
+   * @param {Error} error
+   * @param {string} message
+   * @param {Object} detail
+   */
+  handleError(error, message, detail) {}
+}

--- a/third_party/stimulus/v1_1_1/externs/binding.js
+++ b/third_party/stimulus/v1_1_1/externs/binding.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Externs for `binding.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/binding.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+Stimulus.Binding = class {
+
+  /**
+   *
+   * @param {!Stimulus.Context} context
+   * @param {!Stimulus.Action} action
+   */
+  constructor(context, action) {
+    /** @type {!Stimulus.Context} */
+    this.context;
+
+    /** @type {!Stimulus.Action} */
+    this.action;
+  }
+
+  /** @returns {!number} */
+  index() { }
+
+  /** @returns {!EventTarget} */
+  eventTarget() { }
+
+  /** @returns {!string} */
+  identifier() { }
+
+  /** @returns {!Event} */
+  handleEvent(event) { }
+
+  /** @returns {!string} */
+  eventName() { }
+
+  /** @returns {!Function} */
+  method() { }
+};

--- a/third_party/stimulus/v1_1_1/externs/binding_observer.js
+++ b/third_party/stimulus/v1_1_1/externs/binding_observer.js
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Externs for `binding_observer.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/binding_observer.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @interface
+ * @extends {Stimulus.ErrorHandler}
+ */
+Stimulus.BindingObserverDelegate = class {
+
+  /**
+   *
+   * @param {!Stimulus.Binding} binding
+   */
+  bindingConnected(binding) {}
+
+  /**
+   *
+   * @param {!Stimulus.Binding} binding
+   */
+  bindingDisconnected(binding) {}
+};
+
+/**
+ * // implements {Stimulus.ValueListObserverDelegate<Action>}
+ * @template Action
+ */
+Stimulus.BindingObserver = class {
+
+  /**
+   *
+   * @param {!Stimulus.Context} context
+   * @param {!Stimulus.BindingObserverDelegate} delegate
+   */
+  constructor(context, delegate) {
+    /** @type {!Stimulus.Context} */
+    this.context;
+
+    /** @type {!Stimulus.BindingObserverDelegate} */
+    this.delegate;
+
+    // this.bindingsByAction = new Map
+  }
+
+  /**  */
+  start() { }
+
+  /** */
+  stop() { }
+
+  /**
+   * @returns {!Element}
+   */
+  element() { }
+
+  /**
+   * @returns {!string}
+   */
+  identifier() { }
+
+  /**
+   * @returns {!string}
+   */
+  actionAttribute() { }
+
+  /**
+   * @returns {!Stimulus.Schema}
+   */
+  schema() { }
+
+  /**
+   * @returns {!Array<!Stimulus.Binding>}
+   */
+  bindings() { }
+
+  // Value observer delegate
+
+  /**
+   *
+   * @param {*} token (technically, !Stimulus.Token)
+   * @returns {?Action}
+   */
+  parseValueForToken(token) { }
+
+  /**
+   *
+   * @param {!Element} element
+   * @param {!Stimulus.Action} action
+   */
+  elementMatchedValue(element, action) { }
+
+  /**
+   *
+   * @param {!Element} element
+   * @param {!Stimulus.Action} action
+   */
+  elementUnmatchedValue(element, action) { }
+}

--- a/third_party/stimulus/v1_1_1/externs/context.js
+++ b/third_party/stimulus/v1_1_1/externs/context.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Externs for `context.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/context.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @implements {Stimulus.ErrorHandler}
+ */
+Stimulus.Context = class Context {
+
+  /**
+   * @param {!Stimulus.Module} module
+   * @param {!Stimulus.Scope} scope
+   */
+  constructor(module, scope) {
+    /** @type {Stimulus.Module} */
+    this.module;
+
+    /** @type {!Stimulus.Scope} */
+    this.scope;
+
+    /** @type {!Stimulus.Controller} */
+    this.controller;
+
+    /** @type {!Stimulus.BindingObserver} */
+    this.bindingObserver;
+  }
+
+  /** */
+  connect() { }
+
+  /** */
+  disconnect() { }
+
+  /**
+   * @return {!Stimulus.Application}
+   */
+  application() { }
+
+  /**
+   * @return {!string}
+   */
+  identifier() { }
+
+  /**
+   * @return {!Stimulus.Schema}
+   */
+  schema() { }
+
+  /**
+   * @return {!Stimulus.Dispatcher}
+   */
+  dispatcher() {  }
+
+  /**
+   * @return {?Element}
+   */
+  element() { }
+
+  /**
+   * @return {?Element}
+   */
+  parentElement() { }
+
+  // Error handling
+
+  /**
+   * @param {!Error} error
+   * @param {!string} message
+   * @param {!Object} detail
+   */
+  handleError(error, message, detail = {}) { }
+}

--- a/third_party/stimulus/v1_1_1/externs/controller.js
+++ b/third_party/stimulus/v1_1_1/externs/controller.js
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Externs for `controller.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/controller.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @interface
+ */
+Stimulus.ControllerConstructor = class {
+  /** */
+  bless() { }
+
+  /**
+   *
+   * @param {!Stimulus.Context} context
+   * @returns {!Stimulus.Controller}
+   */
+  new(context) { }
+}
+
+/**
+ * @implements {Stimulus.ControllerConstructor}
+ */
+Stimulus.Controller = class {
+
+  /** */
+  static bless() { }
+
+  /**
+   *
+   * @param {!Stimulus.Context} context
+   */
+  constructor(context) {
+    /** @type {!Stimulus.Context} */
+    this.context;
+  }
+
+  /** @returns {!Stimulus.Application} */
+  get application() { }
+
+  /** @returns {!Stimulus.Scope} */
+  get scope() { }
+
+  /** @returns {!Element} */
+  get element() { }
+
+  /** @returns {!string} */
+  get identifier() { }
+
+  /** @returns {!Stimulus.TargetSet} */
+  get targets() { }
+
+  /** @returns {!Stimulus.DataMap} */
+  get data() { }
+
+  /** */
+  initialize() { }
+
+  /** */
+  connect() { }
+
+  /** */
+  disconnect() { }
+};
+
+/** @type {!Array<!string>} */
+Stimulus.Controller.targets;

--- a/third_party/stimulus/v1_1_1/externs/data_map.js
+++ b/third_party/stimulus/v1_1_1/externs/data_map.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Externs for `data_map.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/data_map.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+Stimulus.DataMap = class {
+
+  /**
+   * @param {!Stimulus.Scope} scope
+   */
+  constructor(scope) {
+    /** @type {!Stimulus.Scope} */
+    this.scope;
+  }
+
+  /** @returns {!Element} */
+  element() { }
+
+
+  /** @returns {!string} */
+  identifier() { }
+
+  /**
+   *
+   * @param {!string} key
+   * @returns {!string|null}
+   */
+  get(key) { }
+
+  /**
+   *
+   * @param {!string} key
+   * @param {!string} value
+   * @returns {!string|null}
+   */
+  set(key, value) { }
+
+  /**
+   *
+   * @param {!string} key
+   * @returns {!boolean}
+   */
+  has(key) { }
+
+  /**
+   *
+   * @param {!string} key
+   * @returns {!boolean}
+   */
+  delete(key) { }
+};

--- a/third_party/stimulus/v1_1_1/externs/definition.js
+++ b/third_party/stimulus/v1_1_1/externs/definition.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Externs for `definition.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/definition.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @interface
+ */
+Stimulus.Definition;
+
+/** @type {!string} */
+Stimulus.Definition.prototype.identifier;
+
+/** @type {!Stimulus.ControllerConstructor} */
+Stimulus.Definition.prototype.controllerConstructor;

--- a/third_party/stimulus/v1_1_1/externs/dispatcher.js
+++ b/third_party/stimulus/v1_1_1/externs/dispatcher.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Externs for `dispatcher.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/dispatcher.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @implements {Stimulus.BindingObserverDelegate}
+ */
+Stimulus.Dispatcher = class {
+
+  /**
+   * @param {!Stimulus.Application} application
+   */
+  constructor(application) {
+    /** @type {!Stimulus.Application} */
+    this.application;
+  }
+
+  /** */
+  start() { }
+
+  /** */
+  stop() { }
+
+  /**
+   * @returns {!Array<!EventListener>}
+   */
+  eventListeners() { }
+
+  // Error handling
+
+  /**
+   * @param {Error} error
+   * @param {!string} message
+   * @param {!Object=} detail
+   */
+  handleError(error, message, detail = {}) { }
+}

--- a/third_party/stimulus/v1_1_1/externs/error_handler.js
+++ b/third_party/stimulus/v1_1_1/externs/error_handler.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Externs for `error_handler.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/error_handler.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @interface
+ */
+Stimulus.ErrorHandler = class {
+
+  /**
+   * @param {!Error} error
+   * @param {!string} message
+   * @param {!Object} detail
+   */
+  handleError(error, message, detail) { }
+};

--- a/third_party/stimulus/v1_1_1/externs/module.js
+++ b/third_party/stimulus/v1_1_1/externs/module.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Externs for `error_handler.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/error_handler.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+Stimulus.Module = class {
+
+  /**
+   *
+   * @param {!Stimulus.Application} application
+   * @param {!Stimulus.Definition} definition
+   */
+  constructor(application, definition) {
+    /** @type {!Stimulus.Application} */
+    this.application;
+
+    /** @type {!Stimulus.Definition} */
+    this.definition;
+
+    // this.contextsByScope = new WeakMap
+    // this.connectedContexts = new Set
+  }
+
+  /**
+   * @returns {!string}
+   */
+  identifier() { }
+
+  /**
+   * @returns {!Stimulus.ControllerConstructor}
+   */
+  controllerConstructor() {
+    return this.definition.controllerConstructor
+  }
+
+  /** @returns {!Array<!Stimulus.Context>} */
+  contexts() { }
+
+  /**
+   *
+   * @param {!Stimulus.Scope} scope
+   */
+  connectContextForScope(scope) { }
+
+  /**
+   *
+   * @param {!Stimulus.Scope} scope
+   */
+  disconnectContextForScope(scope) { }
+};

--- a/third_party/stimulus/v1_1_1/externs/router.js
+++ b/third_party/stimulus/v1_1_1/externs/router.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Externs for `router.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/router.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @implements {Stimulus.ScopeObserverDelegate}
+ */
+Stimulus.Router = class {
+
+  /**
+   *
+   * @param {!Stimulus.Application} application
+   */
+  constructor(application) {
+    /** @type {!Stimulus.Application} */
+    this.application;
+
+    /** @type {!Stimulus.ScopeObserver} */
+    this.scopeObserver;
+
+    // this.scopesByIdentifier = new Multimap
+    // this.modulesByIdentifier = new Map
+  }
+
+  /**
+   * @return {!Element}
+   */
+  element() { }
+
+  /**
+   * @return {!Stimulus.Schema}
+   */
+  schema() { }
+
+  /**
+   * @return {!string}
+   */
+  controllerAttribute() { }
+
+  /**
+   * @return {!Array<!Stimulus.Module>}
+   */
+  modules() { }
+
+  /**
+   * @return {!Array<!Stimulus.Context>}
+   */
+  contexts() { }
+
+  /** */
+  start() { }
+
+  /** */
+  stop() { }
+
+  /**
+   * @param {!Stimulus.Definition} definition
+   */
+  loadDefinition(definition) { }
+
+  /**
+   * @param {!string} identifier
+   */
+  unloadIdentifier(identifier) { }
+
+  /**
+   * @param {!Element} element
+   * @param {!string} identifier
+   * @returns {?Stimulus.Context}
+   */
+  getContextForElementAndIdentifier(element, identifier) { }
+
+  // Error handler delegate
+
+  /**
+   * @param {!Error} error
+   * @param {!string} message
+   * @param {*} detail
+   * @hidden
+   */
+  handleError(error, message, detail) { }
+
+  // Scope observer delegate
+
+  /**
+   * @param {!Stimulus.Scope} scope
+   * @hidden
+   */
+  scopeConnected(scope) { }
+
+  /**
+   * @param {!Stimulus.Scope} scope
+   * @hidden
+   */
+  scopeDisconnected(scope) { }
+}

--- a/third_party/stimulus/v1_1_1/externs/schema.js
+++ b/third_party/stimulus/v1_1_1/externs/schema.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Externs for `schema.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/schema.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @typedef {{controllerAttribute: !string, actionAttribute: !string, targetAttribute: !string}}
+ */
+Stimulus.Schema;
+
+/** @type {!Stimulus.Schema} */
+Stimulus.defaultSchema = {
+  controllerAttribute: "data-controller",
+  actionAttribute: "data-action",
+  targetAttribute: "data-target"
+};

--- a/third_party/stimulus/v1_1_1/externs/scope.js
+++ b/third_party/stimulus/v1_1_1/externs/scope.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Externs for `scope.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/scope.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+Stimulus.Scope = class {
+
+  /**
+   *
+   * @param {!Stimulus.Schema} schema
+   * @param {!string} identifier
+   * @param {!Element} element
+   */
+  constructor(schema, identifier, element) {
+    /** @type {!Stimulus.Schema} */
+    this.schema;
+
+    /** @type {!string} */
+    this.identifier;
+
+    /** @type {!Element} */
+    this.element;
+
+    /** @type {!Stimulus.TargetSet} */
+    this.targets;
+
+    /** @type {!Stimulus.DataMap} */
+    this.data;
+  }
+
+  /**
+   *
+   * @param {!string} selector
+   * @returns {?Element}
+   */
+  findElement(selector) { }
+
+  /**
+   *
+   * @param {!string} selector
+   * @returns {!Array<!Element>}
+   */
+  findAllElements(selector) { }
+
+  /**
+   *
+   * @param {!Array<!Element>} elements
+   * @returns {!Array<!Element>}
+   */
+  filterElements(elements) { }
+
+  /**
+   *
+   * @param {!Element} element
+   * @returns {!boolean}
+   */
+  containsElement(element) { }
+};

--- a/third_party/stimulus/v1_1_1/externs/scope_observer.js
+++ b/third_party/stimulus/v1_1_1/externs/scope_observer.js
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Externs for `scope_observer.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/scope_observer.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+/**
+ * @interface
+ * @extends {Stimulus.ErrorHandler}
+ */
+Stimulus.ScopeObserverDelegate = class {
+  /**
+   *
+   * @param {!Stimulus.Scope} scope
+   */
+  scopeConnected(scope) {}
+
+  /**
+   *
+   * @param {!Stimulus.Scope} scope
+   */
+  scopeDisconnected(scope) {}
+}
+
+/**
+ * // implements {ValueListObserverDelegate<Scope>}
+ */
+Stimulus.ScopeObserver = class {
+
+  /**
+   *
+   * @param {!Element} element
+   * @param {!Stimulus.Schema} schema
+   * @param {!Stimulus.ScopeObserverDelegate} delegate
+   */
+  constructor(element, schema, delegate) {
+    /** @type {!Element} */
+    this.element;
+
+    /** @type {!Stimulus.Schema} */
+    this.schema;
+
+    /** @type {!Stimulus.ScopeObserverDelegate} */
+    this.delegate;
+
+    // this.valueListObserver = new ValueListObserver(this.element, this.controllerAttribute, this)
+    // this.scopesByIdentifierByElement = new WeakMap
+    // this.scopeReferenceCounts = new WeakMap
+  }
+
+  /** */
+  start() {  }
+
+  /** */
+  stop() {}
+
+  /** @returns {!string} */
+  controllerAttribute() { }
+
+  // Value observer delegate
+
+  /**
+   * @param {*} token (technically, !Stimulus.Token)
+   * @returns {?Stimulus.Scope}
+   * @hidden
+   */
+  parseValueForToken(token) {  }
+
+  /**
+   * @param {!Element} element
+   * @param {!Stimulus.Scope} value
+   * @hidden
+   */
+  elementMatchedValue(element, value) {  }
+
+  /**
+   * @param {!Element} element
+   * @param {!Stimulus.Scope} value
+   * @hidden
+   */
+  elementUnmatchedValue(element, value) {  }
+};

--- a/third_party/stimulus/v1_1_1/externs/target_set.js
+++ b/third_party/stimulus/v1_1_1/externs/target_set.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Externs for `target_set.ts` from `@stimulus/core`:
+ *     https://github.com/stimulusjs/stimulus/blob/v1.1.1/packages/%40stimulus/core/src/target_set.ts
+ * @externs
+ */
+
+/** @const */
+var Stimulus = {};
+
+Stimulus.TargetSet = class {
+
+  /**
+   *
+   * @param {!Stimulus.Scope} scope
+   */
+  constructor(scope) {
+    /** @type {!Stimulus.Scope} */
+    this.scope;
+  }
+
+  /**
+   * @returns {!Element}
+   */
+  element() { }
+
+  /**
+   * @returns {!string}
+   */
+  identifier() { }
+
+  /**
+   * @returns {!Stimulus.Schema}
+   */
+  schema() { }
+
+  /**
+   *
+   * @param {!string} targetName
+   * @returns {!boolean}
+   */
+  has(targetName) { }
+
+  /**
+   *
+   * @param  {...!string} targetNames
+   * @returns {?Element}
+   */
+  find(...targetNames) { }
+
+  /**
+   *
+   * @param  {...!string} targetNames
+   * @returns {!Array<!Element>}
+   */
+  findAll(...targetNames) { }
+};


### PR DESCRIPTION
Also add Closure Compiler-compatible externs for Stimulus 1.1.1 which are
required to provide typechecking support.