### PR TITLE
Add GitHub Actions build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Using Stimulus.js
 
+[![Build Status][github-ci-badge]][github-ci-url]
+
 How to build applications using [Stimulus.js][stimulus-js].
 
 Working sample apps:
@@ -25,6 +27,8 @@ This project is not an official Google project. It is not supported by Google
 and Google specifically disclaims all warranties as to its quality,
 merchantability, or fitness for a particular purpose.
 
+[github-ci-badge]: https://github.com/mbrukman/using-stimulusjs/actions/workflows/main.yml/badge.svg
+[github-ci-url]: https://github.com/mbrukman/using-stimulusjs/actions/workflows/main.yml
 [stimulus-js]: https://stimulusjs.org/
 [stimulus-hello-world-js]: third_party/stimulus/hello-world-js
 [stimulus-hello-world-js-closure]: third_party/stimulus/hello-world-js-closure


### PR DESCRIPTION
Since this change doesn't affect any code, let's [skip ci].