### PR TITLE
Update Bazel `rules_nodejs` to 3.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,8 +22,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "b3521b29c7cb0c47a1a735cce7e7e811a4f80d8e3720cf3a1b624533e4bb7cb6",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.3.2/rules_nodejs-2.3.2.tar.gz"],
+    sha256 = "6142e9586162b179fdd570a55e50d1332e7d9c030efd853453438d607569721d",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.0.0/rules_nodejs-3.0.0.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
@@ -55,3 +55,11 @@ http_archive(
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
 rules_closure_dependencies()
 rules_closure_toolchains()
+
+# Needed to support concatjs_devserver()
+
+http_archive(
+    name = "io_bazel_rules_webtesting",
+    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+)

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "private": true,
     "devDependencies": {
         "@bazel/bazelisk": "^1.11.0",
+        "@bazel/concatjs": "^3.0.0",
         "@bazel/ibazel": "^0.16.2",
-        "@bazel/typescript": "^2.2.2",
+        "@bazel/typescript": "^3.0.0",
         "typescript": "^4.6.3",
         "webpack": "^5.3.2",
         "webpack-cli": "^3.3.11"

--- a/third_party/stimulus/hello-world-ts/BUILD
+++ b/third_party/stimulus/hello-world-ts/BUILD
@@ -17,9 +17,11 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+
 package(default_visibility = ["//visibility:public"])
 
-load("@npm//@bazel/typescript:index.bzl", "ts_devserver", "ts_library")
+load("@npm//@bazel/concatjs:index.bzl", "concatjs_devserver")
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("@npm//webpack-cli:index.bzl", "webpack_cli")
 
 ts_library(
@@ -59,7 +61,7 @@ webpack_cli(
     ],
 )
 
-ts_devserver(
+concatjs_devserver(
     name = "devserver",
     port = 5000,
     serving_path = "/bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,15 +7,24 @@
   resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.11.0.tgz#f98d8438b4c14e3328126618b96775d271caa5f8"
   integrity sha512-lxiQzVqSGDG0PIDQGJdVDjp7T+50p5NnM4EnRJa76mkZp6u5ul19GJNKhPKi81TZQALZEZDxAgxVqQKkWTUOxA==
 
+"@bazel/concatjs@^3.0.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@bazel/concatjs/-/concatjs-3.8.0.tgz#a6b2483f7799c58652fbe5347ab2b3063a1ae6ad"
+  integrity sha512-Qi/Glf407LKz7wC3VAGwtm+Sjr/b+RLv7ESdlMekOlzMCK83OWA0aNhKtbSKZ36hJ/ToDgEWtjus7o6svsJECQ==
+  dependencies:
+    protobufjs "6.8.8"
+    source-map-support "0.5.9"
+    tsutils "2.27.2"
+
 "@bazel/ibazel@^0.16.2":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.16.2.tgz#05dd7f06659759fda30f87b15534f1e42f1201bb"
   integrity sha512-KgqAWMH0emL6f3xH6nqyTryoBMqlJ627LBIe9PT1PRRQPz2FtHib3FIHJPukp1slzF3hJYZvdiVwgPnHbaSOOA==
 
-"@bazel/typescript@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-2.2.2.tgz#c7cd49cb630ca3720c04c94046ba8ca4c0d5b0aa"
-  integrity sha512-hkx/7L3s8q5gIgaSFmkUZWPqdKmdJmQ04GaLnsI/YEp9EhPObqATSKnOHeDdT7bzqLO7giDAwAiXhEmsO1Smcw==
+"@bazel/typescript@^3.0.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-3.8.0.tgz#725d51a1c25e314a1d8cddb8b880ac05ba97acd4"
+  integrity sha512-4C1pLe4V7aidWqcPsWNqXFS7uHAB1nH5SUKG5uWoVv4JT9XhkNSvzzQIycMwXs2tZeCylX4KYNeNvfKrmkyFlw==
   dependencies:
     protobufjs "6.8.8"
     semver "5.6.0"


### PR DESCRIPTION
This is a major version upgrade of `rules_nodejs` from 2.3.2 to 3.0.0, which
has had numerous breaking changes:

* https://github.com/bazelbuild/rules_nodejs/releases/tag/3.0.0
* https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-30

First, we had to also update `@bazel/typescript` (previously 2.2.2) because the
major version of `@bazel/typescript` must match the major version of
`rules_nodejs`. We are going a step further and keeping them at the same exact
version to avoid any issues.

Second, `ts_devserver` is no longer present in `rules_nodejs`, so we had to
install `@bazel/concatjs` in addition to other packages, and we've decided to
use the same version (3.0.0) for that package as well.

Next, `ts_devserver` was actually renamed to `contactjs_devserver`, so we had
to make updates per the wiki page (above):

```sh
npx @bazel/buildozer 'new_load @npm//@bazel/concatjs:index.bzl concatjs_devserver' //...:__pkg__
npx @bazel/buildozer 'set kind concatjs_devserver' //...:%ts_devserver
npx @bazel/buildozer 'fix unusedLoads' //...:__pkg__
```

and made some minor cleanups after that.

However, that's not all, because to support `concatjs_devserver`, we also need
to add a dependency on `io_bazel_rules_webtesting`, even though we aren't
technically running any tests, which was added to the `WORKSPACE` file:

```bazel
http_archive(
    name = "io_bazel_rules_webtesting",
    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
)
```

All of these changes were required together, but they seem to work now.