### PR TITLE
Upgrade `rules_nodejs` to 4.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node and Yarn (with caching)
         uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '14'
           cache: 'yarn'
 
       - name: Install NPM dependencies via Yarn

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,16 +22,16 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "e79c08a488cc5ac40981987d862c7320cee8741122a2649e9b08e850b6f20442",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.8.0/rules_nodejs-3.8.0.tar.gz"],
+    sha256 = "6f15d75f9e99c19d9291ff8e64e4eb594a6b7d25517760a75ad3621a7a48c2df",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.7.0/rules_nodejs-4.7.0.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 node_repositories(
-    node_version = "12.13.0",
+    node_version = "14.17.5",
     package_json = ["//:package.json"],
-    yarn_version = "1.13.0",
+    yarn_version = "1.22.11",
 )
 
 yarn_install(

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "private": true,
     "devDependencies": {
         "@bazel/bazelisk": "^1.11.0",
-        "@bazel/concatjs": "^3.8.0",
+        "@bazel/concatjs": "^4.6.2",
         "@bazel/ibazel": "^0.16.2",
-        "@bazel/typescript": "^3.8.0",
+        "@bazel/typescript": "^4.6.2",
         "typescript": "^4.6.3",
         "webpack": "^5.72.0",
         "webpack-cli": "^3.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,29 +7,37 @@
   resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.11.0.tgz#f98d8438b4c14e3328126618b96775d271caa5f8"
   integrity sha512-lxiQzVqSGDG0PIDQGJdVDjp7T+50p5NnM4EnRJa76mkZp6u5ul19GJNKhPKi81TZQALZEZDxAgxVqQKkWTUOxA==
 
-"@bazel/concatjs@^3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@bazel/concatjs/-/concatjs-3.8.0.tgz#a6b2483f7799c58652fbe5347ab2b3063a1ae6ad"
-  integrity sha512-Qi/Glf407LKz7wC3VAGwtm+Sjr/b+RLv7ESdlMekOlzMCK83OWA0aNhKtbSKZ36hJ/ToDgEWtjus7o6svsJECQ==
+"@bazel/concatjs@^4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@bazel/concatjs/-/concatjs-4.6.2.tgz#f034a33a2cb5b8a5426c3166ed6ea5857cb31940"
+  integrity sha512-5wpASLPgWU+ti7+/iHquym0mY1lFZkkNUlHPzCjSOBolzdSWO9yFO/S5k2agzULNbNrZInI9IErakyc6K3xvog==
   dependencies:
     protobufjs "6.8.8"
     source-map-support "0.5.9"
-    tsutils "2.27.2"
+    tsutils "3.21.0"
 
 "@bazel/ibazel@^0.16.2":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.16.2.tgz#05dd7f06659759fda30f87b15534f1e42f1201bb"
   integrity sha512-KgqAWMH0emL6f3xH6nqyTryoBMqlJ627LBIe9PT1PRRQPz2FtHib3FIHJPukp1slzF3hJYZvdiVwgPnHbaSOOA==
 
-"@bazel/typescript@^3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-3.8.0.tgz#725d51a1c25e314a1d8cddb8b880ac05ba97acd4"
-  integrity sha512-4C1pLe4V7aidWqcPsWNqXFS7uHAB1nH5SUKG5uWoVv4JT9XhkNSvzzQIycMwXs2tZeCylX4KYNeNvfKrmkyFlw==
+"@bazel/typescript@^4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-4.6.2.tgz#9f07b6f8cfb6b0a0e228e5971de412911c910a90"
+  integrity sha512-AUF7kq82bP6DX9Brihr/eQqvNccxVfSXosFxt80h94og5cmMyoc/euXha6rxlOBP3yWXmSo+/qjzO7o8PWJduQ==
   dependencies:
+    "@bazel/worker" "4.6.2"
     protobufjs "6.8.8"
     semver "5.6.0"
     source-map-support "0.5.9"
-    tsutils "2.27.2"
+    tsutils "3.21.0"
+
+"@bazel/worker@4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-4.6.2.tgz#0bd105344533335327c2edfa3fc65b04c39cdea8"
+  integrity sha512-DLpN6iQAH6uiUraAs4CESyqs60u55fcKmYgOOVObGuLSQQuX49Lw7XRIN90NibRPwpbBDQichWE3zfra0yKTTw==
+  dependencies:
+    google-protobuf "^3.6.1"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -793,6 +801,11 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
+
+google-protobuf@^3.6.1:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.20.0.tgz#8705ab5fb7e91e9578250a4a8ac533a3cc0bc0bb"
+  integrity sha512-hhXv5IKLDIkb0pEm53G053UZGhRAhw3wM5Jk7ly5sGIQRkO1s63FaDqM9QjlrPHygKEE2awUlLP9fFrG6M9vfQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
@@ -1640,10 +1653,10 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tsutils@2.27.2:
-  version "2.27.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
-  integrity sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==
+tsutils@3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
We tried to just upgrade to 4.0.0 to adjust to the breaking changes first, and
then upgrade to another minor release, but no 4.x versions were working for us,
and 4.7.0 was the first and only one that worked. Incidentally, 4.7.0 also
seems like the last 4.x release before the 5.x series, so we'll have to make
another major version upgrade soon.

For historical reference, here's the command we used for testing:

```sh
$ bazel run //third_party/stimulus/hello-world-ts:devserver
```

and the errors we were getting were one of the following:

> ERROR: error loading package 'third_party/stimulus/hello-world-ts': at [...]/.cache/bazel/_bazel_[...]/61a525b3740f61615718cb5fbe184459/external/npm/@bazel/typescript/index.bzl:22:6: at [...]/.cache/bazel/_bazel_[...]/61a525b3740f61615718cb5fbe184459/external/npm/@bazel/typescript/internal/ts_project.bzl:6:6: cannot load '@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel-skylib:lib/partial.bzl': no such file

or

> ERROR: error loading package 'third_party/stimulus/hello-world-ts': at [...]/.cache/bazel/_bazel_[...]/61a525b3740f61615718cb5fbe184459/external/npm/@bazel/typescript/index.bzl:22:6: at [...]/.cache/bazel/_bazel_[...]/61a525b3740f61615718cb5fbe184459/external/npm/@bazel/typescript/internal/ts_project.bzl:7:6: cannot load '@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel-skylib:rules/build_test.bzl': no such file

One of these errors appeared for all versions of `rules_nodejs` we tested
(which was most of 4.x series) until 4.7.0, which worked.

`rules_nodejs` had a number of changes in the 4.0.0 major release:

* https://github.com/bazelbuild/rules_nodejs/releases/tag/4.0.0

To follow the default versions, we have made similar upgrades:

* Node updated to then-current LTS (14.17.5)
* Yarn updated to then-latest (1.22.11)
* updated Node to v15 in the GitHub Actions config

There isn't v4.7.0 for either `@bazel/concatjs` or `@bazel/typescript`, so they
were upgraded to the latest 4.x version, which is 4.6.2 for both of them.