### PR TITLE
Cleanups in TypeScript sample code and externs

### DIFF
--- a/third_party/stimulus/hello-world-ts/hello.ts
+++ b/third_party/stimulus/hello-world-ts/hello.ts
@@ -3,14 +3,14 @@ import { Application, Controller } from "stimulus"
 class HelloController extends Controller {
   static targets = [ "name", "output" ]
 
-	// These declarations are necessary to tell the TypeScript compiler that these
-	// variables exist; the patterns of these automatic variables is documented in
-	// Stimulus: https://stimulusjs.org/reference/targets
-	//
-	// Note that the type of each target needs to be specified manually and must
-	// match the type of HTML node that it is referring to, because the TypeScript
-	// compiler will assume their correctness here, and if they don't match, you
-	// may see a runtime-error instead of a compile-time error.
+  // These declarations are necessary to tell the TypeScript compiler that these
+  // variables exist; the patterns of these automatic variables is documented in
+  // Stimulus: https://stimulusjs.org/reference/targets
+  //
+  // Note that the type of each target needs to be specified manually and must
+  // match the type of HTML node that it is referring to, because the TypeScript
+  // compiler will assume their correctness here, and if they don't match, you
+  // may see a runtime-error instead of a compile-time error.
   declare readonly nameTarget: HTMLInputElement
   declare readonly nameTargets: HTMLInputElement[]
   declare readonly hasNameTargets: boolean

--- a/third_party/stimulus/v1_1_1/externs/controller.js
+++ b/third_party/stimulus/v1_1_1/externs/controller.js
@@ -20,7 +20,7 @@ Stimulus.ControllerConstructor = class {
    * @returns {!Stimulus.Controller}
    */
   new(context) { }
-}
+};
 
 /**
  * @implements {Stimulus.ControllerConstructor}


### PR DESCRIPTION
Adding missing semicolon and converting tabs to spaces; no functional changes.